### PR TITLE
RCE-Prevention: Sanitize cmd input before shell execution

### DIFF
--- a/man.php
+++ b/man.php
@@ -8,8 +8,9 @@ if(!isset($_SESSION['UserData']['Username'])){
 
 
 <?php
-  function runcmd($dock, $cmd) {
-    shell_exec("docker exec ".$dock." mc-send-to-console ".$cmd);
+  function runcmd($dock, $cmdRaw) {
+    $cmdSanitized = escapeshellarg($cmdRaw);
+    shell_exec("docker exec ".$dock." mc-send-to-console ".$cmdSanitized);
     echo 'Command executed (200)<br>';
     echo 'Command: '.$cmd;
   }


### PR DESCRIPTION
Running a command allows authenticated, remote code execution.

Using un-sanitized and un-checked user-input in sensitive areas like shell_exec easily allows an attacker to execute arbitrary commands by breaking out of the original command-area.