### PR TITLE
Server-Log XSS-Prevention

### DIFF
--- a/log.php
+++ b/log.php
@@ -8,5 +8,7 @@ if(!isset($_SESSION['UserData']['Username'])){
 
 
 <?php
-echo str_replace("\n","<br>", shell_exec("docker logs "."mc"));
+$logRaw = shell_exec("docker logs "."mc");
+$logNewlines = str_replace("\n", "<br>", $logRaw);
+echo $logNewlines;
 ?>

--- a/log.php
+++ b/log.php
@@ -9,6 +9,7 @@ if(!isset($_SESSION['UserData']['Username'])){
 
 <?php
 $logRaw = shell_exec("docker logs "."mc");
-$logNewlines = str_replace("\n", "<br>", $logRaw);
+$logSanitized = htmlspecialchars($logRaw);
+$logNewlines = str_replace("\n", "<br>", $logSanitized);
 echo $logNewlines;
 ?>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54639830/220094909-f87db04c-2764-4f4e-a2e2-8045dd4ce485.png)
![image](https://user-images.githubusercontent.com/54639830/220094949-67eab4f1-a08c-4ace-84a5-a51bd72241ad.png)


Passing un-sanitized and un-checked user-input allows html to be specified and executed in the clients browser viewing the console.

This fix sanitizes the output-log before its sent back to the client.